### PR TITLE
Added flask to supervisor

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         - "../deps:/usr/local/lib/python3.6/dist-packages"
         ports:
             - "5000:5000"
-        command: bash -c "pip3 install -r requirements.txt && python3 apis.py"
+        command: bash -c "pip3 install -r requirements.txt && supervisord -c supervisord.conf"
         environment: 
             FLASK_ENV: "development"
             FLASK_APP: apis.py

--- a/docker/flask/Dockerfile
+++ b/docker/flask/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 
 RUN apt-get update \
-  && apt-get install -y python3-pip python3-dev 
+  && apt-get install -y python3-pip python3-dev supervisor
 
 WORKDIR /app
 ENV LC_ALL C.UTF-8

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,7 @@
+[supervisord]
+nodaemon=true
+
+[program:flask]
+command=python3 apis.py
+stderr_logfile=api_out.log
+stdout_logfile=api_error.log


### PR DESCRIPTION
This PR removes the manual intervention in managing the webserver.
Steps:
1. Install supervisor `apt-get install supervisor`
2. Usage `supervisord -c supervisord.conf`

Note: The logging will be done to the files consumer_out.log and consumer_error.log. Also the supervisor will be running in foreground. To make it a daemon, please remove the line 
`nodaemon=true` from the supervisord.conf
